### PR TITLE
Get ResetZeroPosition to work with nonzero offsets

### DIFF
--- a/st/st_test.go
+++ b/st/st_test.go
@@ -146,6 +146,21 @@ func TestPosition(t *testing.T) {
 	assert.Nil(t, err, "error getting position")
 	expectedSteps = 0
 	assert.Equal(t, expectedSteps, position, "position should be equal to %v", expectedSteps)
+
+	// Reset the position to a nonzero value
+	err = motor.ResetZeroPosition(ctx, 1, nil)
+	assert.Nil(t, err, "error resetting position")
+
+	position, err = motor.Position(ctx, nil)
+	assert.Nil(t, err, "error getting position")
+	assert.Equal(t, float64(-StepsPerRev), position)
+
+	err = motor.GoFor(ctx, 600, 1, nil)
+	assert.Nil(t, err, "error executing move command")
+
+	position, err = motor.Position(ctx, nil)
+	assert.Nil(t, err, "error getting position")
+	assert.Equal(t, 0.0, position)
 }
 
 func TestDoCommand(t *testing.T) {


### PR DESCRIPTION
In https://github.com/viam-soleng/viam-appliedmotion/pull/5, I noticed that we could reset to 0 but would always ignore the offset. This PR fixes that, and also fixes a bug about reading negative positions.

Tried on the actual hardware: the new test works fine!