### PR TITLE
bump workflow go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Build
       run: go build -o ${{ env.binary_file_name }} -v .


### PR DESCRIPTION
this should fix the issues on my other PR, but GitHub checks uses main's version of this file, so this needs to be merged first